### PR TITLE
Backports

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,6 +38,7 @@ Merged from 2.2:
  * Release sstables of failed stream sessions only when outgoing transfers are finished (CASSANDRA-11345)
  * StorageService shutdown hook should use a volatile variable (CASSANDRA-11984)
 Merged from 2.1:
+ * Don't skip sstables based on maxLocalDeletionTime (CASSANDRA-12765)
  * Run CommitLog tests with different compression settings (CASSANDRA-9039)
  * cqlsh: apply current keyspace to source command (CASSANDRA-11152)
  * Clear out parent repair session if repair coordinator dies (CASSANDRA-11824)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,8 @@
 3.7
  * Support multiple folders for user defined compaction tasks (CASSANDRA-11765)
  * Fix race in CompactionStrategyManager's pause/resume (CASSANDRA-11922)
+Merged from 3.x:
+ * NullPointerExpception when reading/compacting table (CASSANDRA-11988)
 Merged from 3.0:
  * Correct log message for statistics of offheap memtable flush (CASSANDRA-12776)
  * Fix potential socket leak (CASSANDRA-12329, CASSANDRA-12330)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
  * Support multiple folders for user defined compaction tasks (CASSANDRA-11765)
  * Fix race in CompactionStrategyManager's pause/resume (CASSANDRA-11922)
 Merged from 3.x:
+ * NullPointerException during compaction on table with static columns (CASSANDRA-12336)
  * NullPointerExpception when reading/compacting table (CASSANDRA-11988)
 Merged from 3.0:
  * Correct log message for statistics of offheap memtable flush (CASSANDRA-12776)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
  * Support multiple folders for user defined compaction tasks (CASSANDRA-11765)
  * Fix race in CompactionStrategyManager's pause/resume (CASSANDRA-11922)
 Merged from 3.x:
+ * Avoid sstable corrupt exception due to dropped static column (CASSANDRA-12582)
  * NullPointerException during compaction on table with static columns (CASSANDRA-12336)
  * NullPointerExpception when reading/compacting table (CASSANDRA-11988)
 Merged from 3.0:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
  * Support multiple folders for user defined compaction tasks (CASSANDRA-11765)
  * Fix race in CompactionStrategyManager's pause/resume (CASSANDRA-11922)
 Merged from 3.0:
+ * Correct log message for statistics of offheap memtable flush (CASSANDRA-12776)
  * Fix potential socket leak (CASSANDRA-12329, CASSANDRA-12330)
  * Fix legacy serialization of Thrift-generated non-compound range tombstones
    when communicating with 2.x nodes (CASSANDRA-11930)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
  * Support multiple folders for user defined compaction tasks (CASSANDRA-11765)
  * Fix race in CompactionStrategyManager's pause/resume (CASSANDRA-11922)
 Merged from 3.0:
+ * Fix potential socket leak (CASSANDRA-12329, CASSANDRA-12330)
  * Fix legacy serialization of Thrift-generated non-compound range tombstones
    when communicating with 2.x nodes (CASSANDRA-11930)
  * Fix Directories instantiations where CFS.initialDirectories should be used (CASSANDRA-11849)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
  * Support multiple folders for user defined compaction tasks (CASSANDRA-11765)
  * Fix race in CompactionStrategyManager's pause/resume (CASSANDRA-11922)
 Merged from 3.x:
+ * Don't try to get sstables for non-repairing column families (CASSANDRA-12077)
  * Avoid sstable corrupt exception due to dropped static column (CASSANDRA-12582)
  * NullPointerException during compaction on table with static columns (CASSANDRA-12336)
  * NullPointerExpception when reading/compacting table (CASSANDRA-11988)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,7 @@ Merged from 3.0:
  * AssertionError with MVs on updating a row that isn't indexed due to a null value (CASSANDRA-12247)
  * Fix potential race in schema during new table creation (CASSANDRA-12083)
 Merged from 2.2:
+ * Fix merkle tree depth calculation (CASSANDRA-12580)
  * Persist local metadata earlier in startup sequence (CASSANDRA-11742)
  * cqlsh: fix tab completion for case-sensitive identifiers (CASSANDRA-11664)
  * Avoid showing estimated key as -1 in tablestats (CASSANDRA-11587)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -37,6 +37,7 @@ Merged from 2.2:
  * cqlsh: correctly handle non-ascii chars in error messages (CASSANDRA-11626)
  * Release sstables of failed stream sessions only when outgoing transfers are finished (CASSANDRA-11345)
  * StorageService shutdown hook should use a volatile variable (CASSANDRA-11984)
+ * Split consistent range movement flag correction (CASSANDRA-12786)
 Merged from 2.1:
  * Don't skip sstables based on maxLocalDeletionTime (CASSANDRA-12765)
  * Run CommitLog tests with different compression settings (CASSANDRA-9039)

--- a/src/java/org/apache/cassandra/config/CFMetaData.java
+++ b/src/java/org/apache/cassandra/config/CFMetaData.java
@@ -674,11 +674,19 @@ public final class CFMetaData
         return droppedColumns;
     }
 
+    public ColumnDefinition getDroppedColumnDefinition(ByteBuffer name)
+    {
+        return getDroppedColumnDefinition(name, false);
+    }
+
     /**
      * Returns a "fake" ColumnDefinition corresponding to the dropped column {@code name}
      * of {@code null} if there is no such dropped column.
+     *
+     * @param name - the column name
+     * @param isStatic - whether the column was a static column, if known
      */
-    public ColumnDefinition getDroppedColumnDefinition(ByteBuffer name)
+    public ColumnDefinition getDroppedColumnDefinition(ByteBuffer name, boolean isStatic)
     {
         DroppedColumn dropped = droppedColumns.get(name);
         if (dropped == null)
@@ -688,7 +696,9 @@ public final class CFMetaData
         // it means that it's a dropped column from before 3.0, and in that case using
         // BytesType is fine for what we'll be using it for, even if that's a hack.
         AbstractType<?> type = dropped.type == null ? BytesType.instance : dropped.type;
-        return ColumnDefinition.regularDef(this, name, type);
+        return isStatic
+               ? ColumnDefinition.staticDef(this, name, type)
+               : ColumnDefinition.regularDef(this, name, type);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1295,7 +1295,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                 float flushingOnHeap = Memtable.MEMORY_POOL.onHeap.reclaimingRatio();
                 float flushingOffHeap = Memtable.MEMORY_POOL.offHeap.reclaimingRatio();
                 float thisOnHeap = largest.getAllocator().onHeap().ownershipRatio();
-                float thisOffHeap = largest.getAllocator().onHeap().ownershipRatio();
+                float thisOffHeap = largest.getAllocator().offHeap().ownershipRatio();
                 logger.debug("Flushing largest {} to free up room. Used total: {}, live: {}, flushing: {}, this: {}",
                             largest.cfs, ratio(usedOnHeap, usedOffHeap), ratio(liveOnHeap, liveOffHeap),
                             ratio(flushingOnHeap, flushingOffHeap), ratio(thisOnHeap, thisOffHeap));

--- a/src/java/org/apache/cassandra/db/SerializationHeader.java
+++ b/src/java/org/apache/cassandra/db/SerializationHeader.java
@@ -311,7 +311,8 @@ public class SerializationHeader
                     // If we don't find the definition, it could be we have data for a dropped column, and we shouldn't
                     // fail deserialization because of that. So we grab a "fake" ColumnDefinition that ensure proper
                     // deserialization. The column will be ignore later on anyway.
-                    column = metadata.getDroppedColumnDefinition(name);
+                    boolean isStatic = staticColumns.containsKey(name);
+                    column = metadata.getDroppedColumnDefinition(name, isStatic);
                     if (column == null)
                         throw new RuntimeException("Unknown column " + UTF8Type.instance.getString(name) + " during deserialization");
                 }

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -572,6 +572,7 @@ public class SinglePartitionReadCommand extends ReadCommand
                         if (skippedSSTablesWithTombstones == null)
                             skippedSSTablesWithTombstones = new ArrayList<>();
                         skippedSSTablesWithTombstones.add(sstable);
+
                     }
                     continue;
                 }
@@ -762,7 +763,7 @@ public class SinglePartitionReadCommand extends ReadCommand
                 sstable.incrementReadCount();
                 try (UnfilteredRowIterator iter = StorageHook.instance.makeRowIterator(cfs, sstable, partitionKey(), Slices.ALL, columnFilter(), filter.isReversed(), isForThrift()))
                 {
-                    if (iter.partitionLevelDeletion().isLive())
+                    if (!iter.partitionLevelDeletion().isLive())
                     {
                         sstablesIterated++;
                         result = add(UnfilteredRowIterators.noRowsIterator(iter.metadata(), iter.partitionKey(), Rows.EMPTY_STATIC_ROW, iter.partitionLevelDeletion(), filter.isReversed()), result, filter, sstable.isRepaired());

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -1223,7 +1223,6 @@ public class CompactionManager implements CompactionManagerMBean
 
             // Create Merkle trees suitable to hold estimated partitions for the given ranges.
             // We blindly assume that a partition is evenly distributed on all sstables for now.
-            // determine tree depth from number of partitions, but cap at 20 to prevent large tree.
             MerkleTrees tree = createMerkleTrees(sstables, validator.desc.ranges, cfs);
             long start = System.nanoTime();
             try (AbstractCompactionStrategy.ScannerList scanners = cfs.getCompactionStrategyManager().getScanners(sstables, validator.desc.ranges);
@@ -1284,8 +1283,11 @@ public class CompactionManager implements CompactionManagerMBean
         {
             long numPartitions = rangePartitionCounts.get(range);
             double rangeOwningRatio = allPartitions > 0 ? (double)numPartitions / allPartitions : 0;
+            // determine max tree depth proportional to range size to avoid blowing up memory with multiple tress,
+            // capping at 20 to prevent large tree (CASSANDRA-11390)
             int maxDepth = rangeOwningRatio > 0 ? (int) Math.floor(20 - Math.log(1 / rangeOwningRatio) / Math.log(2)) : 0;
-            int depth = numPartitions > 0 ? (int) Math.min(Math.floor(Math.log(numPartitions)), maxDepth) : 0;
+            // determine tree depth from number of partitions, capping at max tree depth (CASSANDRA-5263)
+            int depth = numPartitions > 0 ? (int) Math.min(Math.ceil(Math.log(numPartitions) / Math.log(2)), maxDepth) : 0;
             tree.addMerkleTree((int) Math.pow(2, depth), range);
         }
         if (logger.isDebugEnabled())

--- a/src/java/org/apache/cassandra/db/partitions/AbstractBTreePartition.java
+++ b/src/java/org/apache/cassandra/db/partitions/AbstractBTreePartition.java
@@ -60,7 +60,7 @@ public abstract class AbstractBTreePartition implements Partition, Iterable<Row>
             this.columns = columns;
             this.tree = tree;
             this.deletionInfo = deletionInfo;
-            this.staticRow = staticRow;
+            this.staticRow = staticRow == null ? Rows.EMPTY_STATIC_ROW : staticRow;
             this.stats = stats;
         }
     }

--- a/src/java/org/apache/cassandra/db/partitions/PurgeFunction.java
+++ b/src/java/org/apache/cassandra/db/partitions/PurgeFunction.java
@@ -55,7 +55,8 @@ public abstract class PurgeFunction extends Transformation<UnfilteredRowIterator
     {
     }
 
-    public UnfilteredRowIterator applyToPartition(UnfilteredRowIterator partition)
+    @Override
+    protected UnfilteredRowIterator applyToPartition(UnfilteredRowIterator partition)
     {
         onNewPartition(partition.partitionKey());
 
@@ -71,24 +72,28 @@ public abstract class PurgeFunction extends Transformation<UnfilteredRowIterator
         return purged;
     }
 
-    public DeletionTime applyToDeletion(DeletionTime deletionTime)
+    @Override
+    protected DeletionTime applyToDeletion(DeletionTime deletionTime)
     {
         return purger.shouldPurge(deletionTime) ? DeletionTime.LIVE : deletionTime;
     }
 
-    public Row applyToStatic(Row row)
+    @Override
+    protected Row applyToStatic(Row row)
     {
         updateProgress();
         return row.purge(purger, nowInSec);
     }
 
-    public Row applyToRow(Row row)
+    @Override
+    protected Row applyToRow(Row row)
     {
         updateProgress();
         return row.purge(purger, nowInSec);
     }
 
-    public RangeTombstoneMarker applyToMarker(RangeTombstoneMarker marker)
+    @Override
+    protected RangeTombstoneMarker applyToMarker(RangeTombstoneMarker marker)
     {
         updateProgress();
         boolean reversed = isReverseOrder;

--- a/src/java/org/apache/cassandra/db/rows/BaseRowIterator.java
+++ b/src/java/org/apache/cassandra/db/rows/BaseRowIterator.java
@@ -53,7 +53,7 @@ public interface BaseRowIterator<U extends Unfiltered> extends CloseableIterator
 
     /**
      * The static part corresponding to this partition (this can be an empty
-     * row).
+     * row but cannot be {@code null}).
      */
     public Row staticRow();
 

--- a/src/java/org/apache/cassandra/db/rows/Row.java
+++ b/src/java/org/apache/cassandra/db/rows/Row.java
@@ -200,7 +200,8 @@ public interface Row extends Unfiltered, Collection<ColumnData>
      *
      * @param purger the {@code DeletionPurger} to use to decide what can be purged.
      * @param nowInSec the current time to decide what is deleted and what isn't (in the case of expired cells).
-     * @return this row but without any deletion info purged by {@code purger}.
+     * @return this row but without any deletion info purged by {@code purger}. If the purged row is empty, returns
+     * {@code null}.
      */
     public Row purge(DeletionPurger purger, int nowInSec);
 
@@ -220,8 +221,14 @@ public interface Row extends Unfiltered, Collection<ColumnData>
     public Row markCounterLocalToBeCleared();
 
     /**
-     * returns a copy of this row where all live timestamp have been replaced by {@code newTimestamp} and every deletion timestamp
-     * by {@code newTimestamp - 1}. See {@link Commit} for why we need this.
+     * Returns a copy of this row where all live timestamp have been replaced by {@code newTimestamp} and every deletion
+     * timestamp by {@code newTimestamp - 1}.
+     *
+     * @param newTimestamp the timestamp to use for all live data in the returned row.
+     * @param a copy of this row with timestamp updated using {@code newTimestamp}. This can return {@code null} in the
+     * rare where the row only as a shadowable row deletion and the new timestamp supersedes it.
+     *
+     * @see Commit for why we need this.
      */
     public Row updateAllTimestamp(long newTimestamp);
 

--- a/src/java/org/apache/cassandra/db/transform/BaseRows.java
+++ b/src/java/org/apache/cassandra/db/transform/BaseRows.java
@@ -52,7 +52,7 @@ implements BaseRowIterator<R>
 
     public Row staticRow()
     {
-        return staticRow;
+        return staticRow == null ? Rows.EMPTY_STATIC_ROW : staticRow;
     }
 
 

--- a/src/java/org/apache/cassandra/db/transform/BaseRows.java
+++ b/src/java/org/apache/cassandra/db/transform/BaseRows.java
@@ -85,7 +85,8 @@ implements BaseRowIterator<R>
         super.add(transformation);
 
         // transform any existing data
-        staticRow = transformation.applyToStatic(staticRow);
+        if (staticRow != null)
+            staticRow = transformation.applyToStatic(staticRow);
         next = applyOne(next, transformation);
         partitionKey = transformation.applyToPartitionKey(partitionKey);
     }

--- a/src/java/org/apache/cassandra/db/transform/Filter.java
+++ b/src/java/org/apache/cassandra/db/transform/Filter.java
@@ -13,7 +13,8 @@ final class Filter extends Transformation
         this.nowInSec = nowInSec;
     }
 
-    public RowIterator applyToPartition(BaseRowIterator iterator)
+    @Override
+    protected RowIterator applyToPartition(BaseRowIterator iterator)
     {
         RowIterator filtered = iterator instanceof UnfilteredRows
                                ? new FilteredRows(this, (UnfilteredRows) iterator)
@@ -25,7 +26,8 @@ final class Filter extends Transformation
         return filtered;
     }
 
-    public Row applyToStatic(Row row)
+    @Override
+    protected Row applyToStatic(Row row)
     {
         if (row.isEmpty())
             return Rows.EMPTY_STATIC_ROW;
@@ -34,12 +36,14 @@ final class Filter extends Transformation
         return row == null ? Rows.EMPTY_STATIC_ROW : row;
     }
 
-    public Row applyToRow(Row row)
+    @Override
+    protected Row applyToRow(Row row)
     {
         return row.purge(DeletionPurger.PURGE_ALL, nowInSec);
     }
 
-    public RangeTombstoneMarker applyToMarker(RangeTombstoneMarker marker)
+    @Override
+    protected RangeTombstoneMarker applyToMarker(RangeTombstoneMarker marker)
     {
         return null;
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -1859,7 +1859,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         return sstableMetadata.maxLocalDeletionTime;
     }
 
-    /** sstable contains no tombstones if maxLocalDeletionTime == Integer.MAX_VALUE */
+    /** sstable contains no tombstones if minLocalDeletionTime == Integer.MAX_VALUE */
     public boolean hasTombstones()
     {
         // sstable contains no tombstone if minLocalDeletionTime is still set to  the default value Integer.MAX_VALUE

--- a/src/java/org/apache/cassandra/repair/Validator.java
+++ b/src/java/org/apache/cassandra/repair/Validator.java
@@ -58,6 +58,7 @@ public class Validator implements Runnable
     public final RepairJobDesc desc;
     public final InetAddress initiator;
     public final int gcBefore;
+    private final boolean evenTreeDistribution;
 
     // null when all rows with the min token have been consumed
     private long validated;
@@ -71,19 +72,25 @@ public class Validator implements Runnable
 
     public Validator(RepairJobDesc desc, InetAddress initiator, int gcBefore)
     {
+        this(desc, initiator, gcBefore, false);
+    }
+
+    public Validator(RepairJobDesc desc, InetAddress initiator, int gcBefore, boolean evenTreeDistribution)
+    {
         this.desc = desc;
         this.initiator = initiator;
         this.gcBefore = gcBefore;
         validated = 0;
         range = null;
         ranges = null;
+        this.evenTreeDistribution = evenTreeDistribution;
     }
 
     public void prepare(ColumnFamilyStore cfs, MerkleTrees tree)
     {
         this.trees = tree;
 
-        if (!tree.partitioner().preservesOrder())
+        if (!tree.partitioner().preservesOrder() || evenTreeDistribution)
         {
             // You can't beat an even tree distribution for md5
             tree.init();

--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -60,11 +60,18 @@ public final class SSLFactory
     {
         SSLContext ctx = createSSLContext(options, true);
         SSLServerSocket serverSocket = (SSLServerSocket)ctx.getServerSocketFactory().createServerSocket();
-        serverSocket.setReuseAddress(true);
-        prepareSocket(serverSocket, options);
-        serverSocket.bind(new InetSocketAddress(address, port), 500);
-
-        return serverSocket;
+        try
+        {
+            serverSocket.setReuseAddress(true);
+            prepareSocket(serverSocket, options);
+            serverSocket.bind(new InetSocketAddress(address, port), 500);
+            return serverSocket;
+        }
+        catch (IllegalArgumentException | SecurityException | IOException e)
+        {
+            serverSocket.close();
+            throw e;
+        }
     }
 
     /** Create a socket and connect */
@@ -72,8 +79,16 @@ public final class SSLFactory
     {
         SSLContext ctx = createSSLContext(options, true);
         SSLSocket socket = (SSLSocket) ctx.getSocketFactory().createSocket(address, port, localAddress, localPort);
-        prepareSocket(socket, options);
-        return socket;
+        try
+        {
+            prepareSocket(socket, options);
+            return socket;
+        }
+        catch (IllegalArgumentException e)
+        {
+            socket.close();
+            throw e;
+        }
     }
 
     /** Create a socket and connect, using any local address */
@@ -81,8 +96,16 @@ public final class SSLFactory
     {
         SSLContext ctx = createSSLContext(options, true);
         SSLSocket socket = (SSLSocket) ctx.getSocketFactory().createSocket(address, port);
-        prepareSocket(socket, options);
-        return socket;
+        try
+        {
+            prepareSocket(socket, options);
+            return socket;
+        }
+        catch (IllegalArgumentException e)
+        {
+            socket.close();
+            throw e;
+        }
     }
 
     /** Just create a socket */
@@ -90,8 +113,16 @@ public final class SSLFactory
     {
         SSLContext ctx = createSSLContext(options, true);
         SSLSocket socket = (SSLSocket) ctx.getSocketFactory().createSocket();
-        prepareSocket(socket, options);
-        return socket;
+        try
+        {
+            prepareSocket(socket, options);
+            return socket;
+        }
+        catch (IllegalArgumentException e)
+        {
+            socket.close();
+            throw e;
+        }
     }
 
     /** Sets relevant socket options specified in encryption settings */

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -945,7 +945,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
             logger.debug("... got ring + schema info");
 
-            if (useStrictConsistency &&
+            if (useStrictConsistency && !allowSimultaneousMoves() &&
                     (
                         tokenMetadata.getBootstrapTokens().valueSet().size() > 0 ||
                         tokenMetadata.getLeavingEndpoints().size() > 0 ||

--- a/src/java/org/apache/cassandra/streaming/DefaultConnectionFactory.java
+++ b/src/java/org/apache/cassandra/streaming/DefaultConnectionFactory.java
@@ -47,15 +47,20 @@ public class DefaultConnectionFactory implements StreamConnectionFactory
         int attempts = 0;
         while (true)
         {
+            Socket socket = null;
             try
             {
-                Socket socket = OutboundTcpConnectionPool.newSocket(peer);
+                socket = OutboundTcpConnectionPool.newSocket(peer);
                 socket.setSoTimeout(DatabaseDescriptor.getStreamingSocketTimeout());
                 socket.setKeepAlive(true);
                 return socket;
             }
             catch (IOException e)
             {
+                if (socket != null)
+                {
+                    socket.close();
+                }
                 if (++attempts >= MAX_CONNECT_ATTEMPTS)
                     throw e;
 

--- a/src/java/org/apache/cassandra/utils/MerkleTree.java
+++ b/src/java/org/apache/cassandra/utils/MerkleTree.java
@@ -535,6 +535,16 @@ public class MerkleTree implements Serializable
         return histbuild.buildWithStdevRangesAroundMean();
     }
 
+    public long rowCount()
+    {
+        long count = 0;
+        for (TreeRange range : new TreeRangeIterator(this))
+        {
+            count += range.hashable.rowsInRange;
+        }
+        return count;
+    }
+
     @Override
     public String toString()
     {

--- a/src/java/org/apache/cassandra/utils/MerkleTrees.java
+++ b/src/java/org/apache/cassandra/utils/MerkleTrees.java
@@ -319,6 +319,16 @@ public class MerkleTrees implements Iterable<Map.Entry<Range<Token>, MerkleTree>
         return merkleTrees.entrySet().iterator();
     }
 
+    public long rowCount()
+    {
+        long totalCount = 0;
+        for (MerkleTree tree : merkleTrees.values())
+        {
+            totalCount += tree.rowCount();
+        }
+        return totalCount;
+    }
+
     public class TreeRangeIterator extends AbstractIterator<MerkleTree.TreeRange> implements
             Iterable<MerkleTree.TreeRange>,
             PeekingIterator<MerkleTree.TreeRange>

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/StaticColumnsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/StaticColumnsTest.java
@@ -296,6 +296,8 @@ public class StaticColumnsTest extends CQLTester
 
         flush();
 
+        Thread.sleep(1000);
+
         compact();
 
         assertRows(execute("SELECT * FROM %s"), row("k1", "c1", null, "v1"));

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/StaticColumnsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/StaticColumnsTest.java
@@ -278,4 +278,26 @@ public class StaticColumnsTest extends CQLTester
         // We shouldn 't allow static when there is not clustering columns
         assertInvalid("ALTER TABLE %s ADD bar2 text static");
     }
+
+    /**
+     * Ensure that deleting and compacting a static row that should be purged doesn't throw.
+     * This is a test for #11988.
+     */
+    @Test
+    public void testStaticColumnPurging() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pkey text, ckey text, value text, static_value text static, PRIMARY KEY(pkey, ckey)) WITH gc_grace_seconds = 0");
+
+        execute("INSERT INTO %s (pkey, ckey, static_value, value) VALUES (?, ?, ?, ?)", "k1", "c1", "s1", "v1");
+
+        flush();
+
+        execute("DELETE static_value FROM %s WHERE pkey = ?", "k1");
+
+        flush();
+
+        compact();
+
+        assertRows(execute("SELECT * FROM %s"), row("k1", "c1", null, "v1"));
+    }
 }

--- a/test/unit/org/apache/cassandra/db/SinglePartitionReadCommandCQLTest.java
+++ b/test/unit/org/apache/cassandra/db/SinglePartitionReadCommandCQLTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import static org.junit.Assert.assertTrue;
+
+public class SinglePartitionReadCommandCQLTest extends CQLTester
+{
+    @Test
+    public void partitionLevelDeletionTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (bucket_id TEXT,name TEXT,data TEXT,PRIMARY KEY (bucket_id, name))");
+        execute("insert into %s (bucket_id, name, data) values ('8772618c9009cf8f5a5e0c18', 'test', 'hello')");
+        getCurrentColumnFamilyStore().forceBlockingFlush();
+        execute("insert into %s (bucket_id, name, data) values ('8772618c9009cf8f5a5e0c19', 'test2', 'hello');");
+        execute("delete from %s where bucket_id = '8772618c9009cf8f5a5e0c18'");
+        getCurrentColumnFamilyStore().forceBlockingFlush();
+        UntypedResultSet res = execute("select * from %s where bucket_id = '8772618c9009cf8f5a5e0c18' and name = 'test'");
+        assertTrue(res.isEmpty());
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
@@ -115,7 +115,7 @@ public class CompactionsTest
         return store;
     }
 
-    private long populate(String ks, String cf, int startRowKey, int endRowKey, int ttl)
+    public static long populate(String ks, String cf, int startRowKey, int endRowKey, int ttl)
     {
         long timestamp = System.currentTimeMillis();
         CFMetaData cfm = Keyspace.open(ks).getColumnFamilyStore(cf).metadata;


### PR DESCRIPTION
    Don't try to get sstables for non-repairing column families
    Patch by marcuse; reviewed by Paulo Motta for CASSANDRA-12077

    Avoid sstable corrupt exception due to dropped static column
    Patch by Stefania Alborghetti; reviewed by Carl Yeksigian for CASSANDRA-12582

    NullPointerException during compaction on table with static columns
    patch by Sylvain Lebresne; reviewed by Carl Yeksigian for CASSANDRA-12336

    NullPointerExpception when reading/compacting table
    patch by Sylvain Lebresne; reviewed by Carl Yeksigian for CASSANDRA-11988

    Split consistent range movement flag correction
    Patch by Sankalp Kohli; Reviewed by Jeff Jirsa for CASSANDRA-12786

    Don't skip sstables based on maxLocalDeletionTime
    Patch by Cameron Zemek; reviewed by marcuse for CASSANDRA-12765

    Correct log message for statistics of offheap memtable flush
    Patch by Kurt Greaves; Reviewed by Jeff Jirsa for CASSANDRA-12776

    Fix unreleased resource sockets
    patch by Arunkumar M; reviewed by yukim for CASSANDRA-12329, 12330

    Fix merkle tree depth calculation
    Patch by Paulo Motta; Reviewed by Yuki Morishita for CASSANDRA-12580