### PR TITLE
Exception when computing read-repair for range tombstones

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
  * Support multiple folders for user defined compaction tasks (CASSANDRA-11765)
  * Fix race in CompactionStrategyManager's pause/resume (CASSANDRA-11922)
 Merged from 3.x:
+ * Exception when computing read-repair for range tombstones (CASSANDRA-12263)
  * Don't try to get sstables for non-repairing column families (CASSANDRA-12077)
  * Avoid sstable corrupt exception due to dropped static column (CASSANDRA-12582)
  * NullPointerException during compaction on table with static columns (CASSANDRA-12336)


### PR DESCRIPTION
patch by Sylvain Lebresne; reviewed by Branimir Lambov for CASSANDRA-12263
updated by Alex Lourie:
  * changed 'Slice.Bound' calls to 'ClusteringBound'
  * update to DataResolverTest.java to use 'ClusteringBound.Kind' instead
  of ''RangeTombstone.Bound.Kind';