### PR TITLE
Bumped logback dependency version to address CVE-2021-42550.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 3.11.11.1
  * Reject empty options and invalid DC names in replication configuration while creating or altering a keyspace (CASSANDRA-12681)
+ * Bumped logback dependency version to address CVE-2021-42550.
 
 3.11.11
  * Binary releases no longer bundle the apidocs (javadoc) (CASSANDRA-16557)

--- a/build.xml
+++ b/build.xml
@@ -346,8 +346,8 @@
           <dependency groupId="org.slf4j" artifactId="slf4j-api" version="1.7.7"/>
           <dependency groupId="org.slf4j" artifactId="log4j-over-slf4j" version="1.7.7"/>
           <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j" version="1.7.7" />
-          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.1.3"/>
-          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.1.3"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.2.10"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.2.10"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.9.10"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.9.10.8"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.9.10"/>

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ cassandra (3.11.11.1) unstable; urgency=medium
   * New release
 
  -- Cameron Zemek <cameron@instaclustr.com>  Thu, 6 Jan 2022 11:10:00 +1000
+ -- Hoang Vu <hoang.vule@instaclustr.com> Thu, 13 Jan 2022 20:40:00 +1000
 
 cassandra (3.11.11) unstable; urgency=medium
 


### PR DESCRIPTION
Bumped logback dependency version to address CVE-2021-42550 for C* 3.11.11.