### PR TITLE
Bumped the snappy-java version for Cassandra 3.11.13

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+3.11.13.2
+ * Bump snappy-java dependency version so that Snappy compression can be used on AWS Graviton instances.
+
 3.11.13.1
  * Reject empty options and invalid DC names in replication configuration while creating or altering a keyspace (CASSANDRA-12681)
 

--- a/build.xml
+++ b/build.xml
@@ -332,7 +332,7 @@
         <license name="The Apache Software License, Version 2.0" url="https://www.apache.org/licenses/LICENSE-2.0.txt"/>
         <scm connection="${scm.connection}" developerConnection="${scm.developerConnection}" url="${scm.url}"/>
         <dependencyManagement>
-          <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.1.7"/>
+          <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.2.6"/>
           <dependency groupId="net.jpountz.lz4" artifactId="lz4" version="1.3.0"/>
           <dependency groupId="com.ning" artifactId="compress-lzf" version="0.8.4"/>
           <dependency groupId="com.google.guava" artifactId="guava" version="18.0">

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,14 @@
+cassandra (3.11.13.2) unstable; urgency=medium
+
+  * New release
+
+ -- Tanvir Hossain <tanvir.hossain@instaclustr.com>  Tue, 27 Jul 2022 17:00:00 +1000
+
 cassandra (3.11.13.1) unstable; urgency=medium
 
   * New release
 
  -- Cameron Zemek <cameron@instaclustr.com>  Tue, 17 May 2022 14:16:00 +1000
-
 
 cassandra (3.11.13) unstable; urgency=medium
 


### PR DESCRIPTION
Bumped it to a version that supports ARM so that Snappy compression can be used on Graviton nodes.

Issue: INS-20103