### PR TITLE
Fix column constraint test

### DIFF
--- a/src/java/org/apache/cassandra/cql3/constraints/ColumnConstraint.java
+++ b/src/java/org/apache/cassandra/cql3/constraints/ColumnConstraint.java
@@ -78,7 +78,6 @@ public abstract class ColumnConstraint<T>
         public static SatisfiabilityChecker[] getSatisfiabilityCheckers()
         {
             List<SatisfiabilityChecker> result = new ArrayList<>();
-
             for (ConstraintType constraintType : ConstraintType.values())
                 result.addAll(Arrays.asList(constraintType.satisfiabilityCheckers));
 


### PR DESCRIPTION
There’s an error when initializing the static ConstraintType object, and the ConstraintType.values() was being called before the static object was done and throwing an NPE.