### PR TITLE
INS-39037, bumped logback core version to 1.3.16

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -588,8 +588,8 @@
           <dependency groupId="org.slf4j" artifactId="slf4j-api" version="1.7.25"/>
           <dependency groupId="org.slf4j" artifactId="log4j-over-slf4j" version="1.7.25"/>
           <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j" version="1.7.25" />
-          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.2.13"/>
-          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.2.13"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.3.16"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.3.16"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.19.2"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.19.2"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.19.2"/>


### PR DESCRIPTION
This patch updates dependencies version of logback to 1.3.16.

This change fixes CVEs inside older Logback version

patch by Rostyslav Porokhnia

Issue on Jira - https://instaclustr.atlassian.net/browse/INS-39037

