### PR TITLE
INS-42775 [cassandra-image] Bump logback to 1.5.33 and SLF4J to 2.0.1…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -585,11 +585,11 @@
           <dependency groupId="org.antlr" artifactId="antlr-runtime" version="3.5.2">
             <exclusion groupId="org.antlr" artifactId="stringtemplate"/>
           </dependency>
-          <dependency groupId="org.slf4j" artifactId="slf4j-api" version="1.7.25"/>
-          <dependency groupId="org.slf4j" artifactId="log4j-over-slf4j" version="1.7.25"/>
-          <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j" version="1.7.25" />
-          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.2.13"/>
-          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.2.13"/>
+          <dependency groupId="org.slf4j" artifactId="slf4j-api" version="2.0.17"/>
+          <dependency groupId="org.slf4j" artifactId="log4j-over-slf4j" version="2.0.17"/>
+          <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j" version="2.0.17" />
+          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.5.33"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.5.33"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.21.4"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.21.4"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.21"/>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -23,8 +23,6 @@ appender reference in the root level section below.
 -->
 
 <configuration scan="true" scanPeriod="60 seconds">
-  <jmxConfigurator />
-
   <!-- No shutdown hook; we run it ourselves in StorageService after shutdown -->
 
   <!-- SYSTEMLOG rolling file appender to system.log (INFO level) -->

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -17,6 +17,7 @@
  under the License.
 -->
 
+
 <!--
 In order to disable debug.log, comment-out the ASYNCDEBUGLOG
 appender reference in the root level section below.

--- a/src/java/org/apache/cassandra/utils/logging/LogbackLoggingSupport.java
+++ b/src/java/org/apache/cassandra/utils/logging/LogbackLoggingSupport.java
@@ -18,15 +18,9 @@
 
 package org.apache.cassandra.utils.logging;
 
-import java.lang.management.ManagementFactory;
-import java.security.AccessControlException;
 import java.util.Iterator;
 import java.util.Map;
 
-import javax.management.JMX;
-import javax.management.ObjectName;
-
-import org.apache.cassandra.security.ThreadAwareSecurityManager;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
 
@@ -35,13 +29,10 @@ import com.google.common.collect.Maps;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.jmx.JMXConfiguratorMBean;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.TurboFilterList;
-import ch.qos.logback.classic.turbo.ReconfigureOnChangeFilter;
-import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.classic.util.ContextInitializer;
 import ch.qos.logback.core.Appender;
-import ch.qos.logback.core.hook.DelayingShutdownHook;
+import ch.qos.logback.core.hook.DefaultShutdownHook;
 
 /**
  * Encapsulates all logback-specific implementations in a central place.
@@ -57,37 +48,14 @@ public class LogbackLoggingSupport implements LoggingSupport
     @Override
     public void onStartup()
     {
-        // The default logback configuration in conf/logback.xml allows reloading the
-        // configuration when the configuration file has changed (every 60 seconds by default).
-        // This requires logback to use file I/O APIs. But file I/O is not allowed from UDFs.
-        // I.e. if logback decides to check for a modification of the config file while
-        // executing a sandbox thread, the UDF execution and therefore the whole request
-        // execution will fail with an AccessControlException.
-        // To work around this, a custom ReconfigureOnChangeFilter is installed, that simply
-        // prevents this configuration file check and possible reload of the configuration,
-        // while executing sandboxed UDF code.
-        //
-        // NOTE: this is obsolte with logback versions (at least since 1.2.3)
-        Logger logbackLogger = (Logger) LoggerFactory.getLogger(ThreadAwareSecurityManager.class);
-        LoggerContext ctx = logbackLogger.getLoggerContext();
-
-        TurboFilterList turboFilterList = ctx.getTurboFilterList();
-        for (int i = 0; i < turboFilterList.size(); i++)
-        {
-            TurboFilter turboFilter = turboFilterList.get(i);
-            if (turboFilter instanceof ReconfigureOnChangeFilter)
-            {
-                ReconfigureOnChangeFilter reconfigureOnChangeFilter = (ReconfigureOnChangeFilter) turboFilter;
-                turboFilterList.set(i, new SMAwareReconfigureOnChangeFilter(reconfigureOnChangeFilter));
-                break;
-            }
-        }
+        // The SMAwareReconfigureOnChangeFilter workaround (for UDF sandbox AccessControlException)
+        // was already marked obsolete since logback 1.2.3. No startup action is required.
     }
 
     @Override
     public void onShutdown()
     {
-        DelayingShutdownHook logbackHook = new DelayingShutdownHook();
+        DefaultShutdownHook logbackHook = new DefaultShutdownHook();
         logbackHook.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
         logbackHook.run();
     }
@@ -100,10 +68,9 @@ public class LogbackLoggingSupport implements LoggingSupport
         // if both classQualifier and rawLevel are empty, reload from configuration
         if (StringUtils.isBlank(classQualifier) && StringUtils.isBlank(rawLevel))
         {
-            JMXConfiguratorMBean jmxConfiguratorMBean = JMX.newMBeanProxy(ManagementFactory.getPlatformMBeanServer(),
-                                                                          new ObjectName("ch.qos.logback.classic:Name=default,Type=ch.qos.logback.classic.jmx.JMXConfigurator"),
-                                                                          JMXConfiguratorMBean.class);
-            jmxConfiguratorMBean.reloadDefaultConfiguration();
+            LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+            loggerContext.reset();
+            new ContextInitializer(loggerContext).autoConfig();
             return;
         }
         // classQualifier is set, but blank level given
@@ -138,32 +105,4 @@ public class LogbackLoggingSupport implements LoggingSupport
         return it.hasNext();
     }
 
-    /**
-     * The purpose of this class is to prevent logback from checking for config file change,
-     * if the current thread is executing a sandboxed thread to avoid {@link AccessControlException}s.
-     *
-     * This is obsolete with logback versions that replaced {@link ReconfigureOnChangeFilter}
-     * with {@link ch.qos.logback.classic.joran.ReconfigureOnChangeTask} (at least logback since 1.2.3).
-     */
-    private static class SMAwareReconfigureOnChangeFilter extends ReconfigureOnChangeFilter
-    {
-        SMAwareReconfigureOnChangeFilter(ReconfigureOnChangeFilter reconfigureOnChangeFilter)
-        {
-            setRefreshPeriod(reconfigureOnChangeFilter.getRefreshPeriod());
-            setName(reconfigureOnChangeFilter.getName());
-            setContext(reconfigureOnChangeFilter.getContext());
-            if (reconfigureOnChangeFilter.isStarted())
-            {
-                reconfigureOnChangeFilter.stop();
-                start();
-            }
-        }
-
-        protected boolean changeDetected(long now)
-        {
-            if (ThreadAwareSecurityManager.isSecuredThread())
-                return false;
-            return super.changeDetected(now);
-        }
-    }
 }

--- a/test/conf/logback-jmh.xml
+++ b/test/conf/logback-jmh.xml
@@ -23,7 +23,6 @@ appender reference in the root level section below.
 -->
 
 <configuration scan="false" scanPeriod="60 seconds">
-  <jmxConfigurator />
   <!-- No shutdown hook; we run it ourselves in StorageService after shutdown -->
 
   <!-- SYSTEMLOG rolling file appender to system.log (INFO level) -->


### PR DESCRIPTION
Resolves the following logback-core CVEs bundled in the Cassandra deb package:
- CVE-2024-12798 (Medium) - fixed in 1.5.13
- CVE-2024-12801 (Low)    - fixed in 1.5.13
- CVE-2025-11226 (Medium) - fixed in 1.5.19
- CVE-2026-1225  (Low)    - fixed in 1.5.25
- CVE-2026-9828  (Low)    - fixed in 1.5.33

Changes:
- build.xml: bump logback-core/classic 1.2.13 -> 1.5.33, slf4j-* 1.7.25 -> 2.0.17
- LogbackLoggingSupport.java: replace removed JMXConfiguratorMBean with ContextInitializer.autoConfig() for config reload; replace removed DelayingShutdownHook with DefaultShutdownHook; remove obsolete SMAwareReconfigureOnChangeFilter (already marked obsolete since logback 1.2.3)
- conf/logback.xml, test/conf/logback-jmh.xml: remove <jmxConfigurator />
  (JMX package removed in logback 1.5.x)